### PR TITLE
Fix alias type parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ type Group struct {
 }
 
 type User struct {
+	_         struct{}  `json:"-" openapiDesc:"User"`
 	ID        uint      `json:"id"`
 	Name      string    `json:"name"`
-	Email     string    `json:"email"`
+	Email     string    `json:"email" openapiDesc:"User's email'"`
 	IsAdmin   bool      `json:"is_admin"`
 	Groups    []Group   `json:"groups"`
 	CreatedAt time.Time `json:"created_at"`
+	Status    string    `json:"status" openapiEnum:"new confirmed deleted"`
 }
 
 type createUserRequest struct {

--- a/openapi.go
+++ b/openapi.go
@@ -19,13 +19,14 @@ type Property struct {
 
 type Schema struct {
 	// service field for deduplication
-	importPath string              `yaml:"-"`
-	Type       string              `yaml:"type,omitempty"`
-	Format     string              `yaml:"format,omitempty"`
-	Ref        string              `yaml:"$ref,omitempty"`
-	Properties map[string]Property `yaml:"properties,omitempty"`
-	Required   []string            `yaml:"required,omitempty"`
-	Items      *Schema             `yaml:"items,omitempty"`
+	importPath  string              `yaml:"-"`
+	Type        string              `yaml:"type,omitempty"`
+	Format      string              `yaml:"format,omitempty"`
+	Ref         string              `yaml:"$ref,omitempty"`
+	Properties  map[string]Property `yaml:"properties,omitempty"`
+	Required    []string            `yaml:"required,omitempty"`
+	Items       *Schema             `yaml:"items,omitempty"`
+	Description string              `yaml:"description,omitempty"`
 }
 
 type Content struct {

--- a/parser.go
+++ b/parser.go
@@ -387,6 +387,16 @@ func (p *Parser) parseStruct(t *ParsedType) (*Schema, error) {
 	schema.importPath = st.Pkg
 	schema.Type = "object"
 	for i := range st.Fields {
+		params, err := getParamsFromTag(st.Fields[i].Tag)
+		if err != nil {
+			return nil, err
+		}
+
+		if st.Fields[i].IsSystem {
+			schema.Description = params["description"]
+			continue
+		}
+
 		name := st.Fields[i].Name
 		tag := getTag(st.Fields[i].Tag, "json")
 		if tag == "-" {
@@ -394,11 +404,6 @@ func (p *Parser) parseStruct(t *ParsedType) (*Schema, error) {
 		}
 		if tag != "" {
 			name = tag
-		}
-
-		params, err := getParamsFromTag(st.Fields[i].Tag)
-		if err != nil {
-			return nil, err
 		}
 
 		property := Property{

--- a/parser_test.go
+++ b/parser_test.go
@@ -288,6 +288,15 @@ func TestParseStruct(t *testing.T) {
 
 	// even more nested struct with duplicate module name
 	require.Equal(t, "github.com/onrik/gaws/tests/nested/nested", parser.doc.Components.Schemas["nested.NestedStruct"].importPath)
+
+	// struct description
+	s, err = parser.parseStruct(&ParsedType{
+		Name: "DescriptionStruct",
+		Kind: structType,
+		File: getFile(t, "tests", "tests/description_structs.go", ""),
+	})
+	require.Nil(t, err)
+	require.Equal(t, "Test description", parser.doc.Components.Schemas["DescriptionStruct"].Description)
 }
 
 func TestTypeToProperty(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -77,10 +77,20 @@ func TestParseRequest(t *testing.T) {
 	require.True(t, e)
 	require.Equal(t, "", content.Example)
 	require.Equal(t, "", content.Schema.Type)
-	require.NotEqual(t, "", content.Schema.Ref)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Ref)
+
+	// Test array of structs
+	body, err = parser.parseRequest(`@openapiRequest application/json []User`, getFile(t, "tests", "tests/structs.go", ""))
+	require.Nil(t, err)
+
+	content, e = body.Content["application/json"]
+	require.True(t, e)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "array", content.Schema.Type)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Items.Ref)
 
 	// Test json schema
-	body, err = parser.parseRequest(`@openapiRequest application/json {"user": User, "id": int}`, File{})
+	body, err = parser.parseRequest(`@openapiRequest application/json {"user": User, "id": int}`, getFile(t, "tests", "tests/structs.go", ""))
 	require.Nil(t, err)
 
 	content, e = body.Content["application/json"]
@@ -88,6 +98,39 @@ func TestParseRequest(t *testing.T) {
 	require.Equal(t, "", content.Example)
 	require.Equal(t, "object", content.Schema.Type)
 	require.Equal(t, "integer", content.Schema.Properties["id"].Type)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Properties["user"].Ref)
+
+	// Test json schema with array
+	body, err = parser.parseRequest(`@openapiRequest application/json {"user": []User, "id": int}`, getFile(t, "tests", "tests/structs.go", ""))
+	require.Nil(t, err)
+
+	content, e = body.Content["application/json"]
+	require.True(t, e)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "array", content.Schema.Properties["user"].Type)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Properties["user"].Items.Ref)
+
+	// Test json schema with nested struct
+	body, err = parser.parseRequest(`@openapiRequest application/json {"user": nested.NestedStruct, "id": int}`, getFile(t, "tests", "tests/structs4.go", ""))
+	require.Nil(t, err)
+
+	content, e = body.Content["application/json"]
+	require.True(t, e)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "#/components/schemas/NestedStruct", content.Schema.Properties["user"].Ref)
+
+	// Test json schema with array of nested structs
+	body, err = parser.parseRequest(`@openapiRequest application/json {"user": []nested.NestedStruct, "id": int}`, getFile(t, "tests", "tests/structs4.go", ""))
+	require.Nil(t, err)
+
+	content, e = body.Content["application/json"]
+	require.True(t, e)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "array", content.Schema.Properties["user"].Type)
+	require.Equal(t, "#/components/schemas/NestedStruct", content.Schema.Properties["user"].Items.Ref)
 }
 
 func TestParseResponse(t *testing.T) {
@@ -126,7 +169,15 @@ func TestParseResponse(t *testing.T) {
 	require.Equal(t, "application/json", contentType)
 	require.Equal(t, "", content.Example)
 	require.Equal(t, "", content.Schema.Type)
-	require.NotEqual(t, "", content.Schema.Ref)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Ref)
+
+	// Test array of structs
+	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/json []User`, getFile(t, "tests", "tests/structs.go", ""))
+	require.Nil(t, err)
+	require.Equal(t, "200", status)
+	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "array", content.Schema.Type)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Items.Ref)
 
 	// Test json schema
 	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/json {"user": User, "id": int}`, File{})
@@ -136,6 +187,35 @@ func TestParseResponse(t *testing.T) {
 	require.Equal(t, "", content.Example)
 	require.Equal(t, "object", content.Schema.Type)
 	require.Equal(t, "integer", content.Schema.Properties["id"].Type)
+
+	// Test json schema with array
+	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/json {"user": []User, "id": int}`, getFile(t, "tests", "tests/structs.go", ""))
+	require.Nil(t, err)
+	require.Equal(t, "200", status)
+	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "array", content.Schema.Properties["user"].Type)
+	require.Equal(t, "#/components/schemas/User", content.Schema.Properties["user"].Items.Ref)
+
+	// Test json schema with nested struct
+	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/json {"user": nested.NestedStruct, "id": int}`, getFile(t, "tests", "tests/structs4.go", ""))
+	require.Nil(t, err)
+	require.Equal(t, "200", status)
+	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "#/components/schemas/NestedStruct", content.Schema.Properties["user"].Ref)
+
+	// Test json schema with array of nested structs
+	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/json {"user": []nested.NestedStruct, "id": int}`, getFile(t, "tests", "tests/structs4.go", ""))
+	require.Nil(t, err)
+	require.Equal(t, "200", status)
+	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "", content.Example)
+	require.Equal(t, "object", content.Schema.Type)
+	require.Equal(t, "array", content.Schema.Properties["user"].Type)
+	require.Equal(t, "#/components/schemas/NestedStruct", content.Schema.Properties["user"].Items.Ref)
 
 	// Test application/octet-stream
 	status, contentType, content, err = parser.parseResponse(`@openapiResponse 200 application/octet-stream`, File{})
@@ -154,11 +234,19 @@ func TestParseStruct(t *testing.T) {
 	}
 	parser := NewParser(&doc, newStructsParser())
 
-	s, err := parser.parseStruct("Test", getFile(t, "tests", "tests/uuid_structs.go", ""))
+	s, err := parser.parseStruct(&ParsedType{
+		Name: "Test",
+		Kind: structType,
+		File: getFile(t, "tests", "tests/uuid_structs.go", ""),
+	})
 	require.NotNil(t, err)
 	require.Equal(t, "struct type with name 'Test' was not found in package 'tests' with import path ''", err.Error())
 
-	s, err = parser.parseStruct("UUIDUser", getFile(t, "tests", "tests/structs.go", ""))
+	s, err = parser.parseStruct(&ParsedType{
+		Name: "UUIDUser",
+		Kind: structType,
+		File: getFile(t, "tests", "tests/uuid_structs.go", ""),
+	})
 	require.Nil(t, err)
 	require.Equal(t, "", s.Type)
 	require.NotEqual(t, "", s.Ref)
@@ -175,17 +263,30 @@ func TestParseStruct(t *testing.T) {
 	require.Equal(t, "testDescription", user.Properties["description"].Description)
 
 	// using cache
-	s, err = parser.parseStruct("[]UUIDUser", File{})
+	s, err = parser.parseStruct(&ParsedType{
+		Name: "[]UUIDUser",
+		Kind: arrayType,
+		File: File{},
+		Nested: &ParsedType{
+			Name: "UUIDUser",
+			Kind: structType,
+			File: File{},
+		},
+	})
 	require.Nil(t, err)
 	require.Equal(t, "array", s.Type)
 
 	// nested struct
-	s, err = parser.parseStruct("nested.NestedStruct", getFile(t, "tests", "tests/structs4.go", ""))
+	s, err = parser.parseStruct(&ParsedType{
+		Name: "Struct4",
+		Kind: structType,
+		File: getFile(t, "tests", "tests/structs4.go", ""),
+	})
 	require.Nil(t, err)
-	require.Equal(t, "github.com/onrik/gaws/tests/nested", s.importPath)
+	require.Equal(t, "", s.importPath)
+	require.Equal(t, "github.com/onrik/gaws/tests/nested", parser.doc.Components.Schemas["NestedStruct"].importPath)
 
 	// even more nested struct with duplicate module name
-	require.Equal(t, "github.com/onrik/gaws/tests/nested", parser.doc.Components.Schemas["NestedStruct"].importPath)
 	require.Equal(t, "github.com/onrik/gaws/tests/nested/nested", parser.doc.Components.Schemas["nested.NestedStruct"].importPath)
 }
 
@@ -195,58 +296,76 @@ func TestTypeToProperty(t *testing.T) {
 		Paths:      map[string]Path{},
 		Components: Component{map[string]SecurityScheme{}, map[string]*Schema{}}}, newStructsParser())
 
-	p, err := parser.typeToProperty("", "int", File{})
+	p, err := parser.typeToProperty(parser.mustParseType("int", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "integer", p.Type)
 	require.Equal(t, "", p.Format)
 
-	p, err = parser.typeToProperty("", "*int", File{})
+	p, err = parser.typeToProperty(parser.mustParseType("*int", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "integer", p.Type)
 	require.Equal(t, "", p.Format)
 
-	p, err = parser.typeToProperty("", "string", File{})
+	p, err = parser.typeToProperty(parser.mustParseType("string", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "string", p.Type)
 	require.Equal(t, "", p.Format)
 
-	p, err = parser.typeToProperty("", "time.Time", File{})
+	p, err = parser.typeToProperty(parser.mustParseType("time.Time", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "string", p.Type)
 	require.Equal(t, "date-time", p.Format)
 
-	p, err = parser.typeToProperty("", "*time.Time", File{})
+	p, err = parser.typeToProperty(parser.mustParseType("*time.Time", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "string", p.Type)
 	require.Equal(t, "date-time", p.Format)
 
-	p, err = parser.typeToProperty("", "[]string", File{})
+	p, err = parser.typeToProperty(parser.mustParseType("[]string", File{}))
 	require.Nil(t, err)
 	require.Equal(t, "array", p.Type)
 	require.NotNil(t, p.Items)
 	require.Equal(t, "string", p.Items.Type)
 
-	p, err = parser.typeToProperty("", "User", getFile(t, "nested", "tests/nested/nested.go", "github.com/onrik/gaws/tests/nested"))
-	require.NotNil(t, err)
-	require.Equal(t, "type with name 'User' was not found in package 'tests/nested' with import path 'github.com/onrik/gaws/tests/nested'", err.Error())
-
-	p, err = parser.typeToProperty("", "User", getFile(t, "tests", "tests/structs.go", ""))
+	p, err = parser.typeToProperty(parser.mustParseType("User", getFile(t, "tests", "tests/structs.go", "")))
 	require.Nil(t, err)
 	require.Equal(t, "#/components/schemas/User", p.Ref)
 
 	// alias
-	p, err = parser.typeToProperty("", "Alias", getFile(t, "tests", "tests/alias_structs.go", ""))
+	p, err = parser.typeToProperty(parser.mustParseType("Alias", getFile(t, "tests", "tests/alias_structs.go", "")))
 	require.Nil(t, err)
 	require.Equal(t, "#/components/schemas/StructForAlias", p.Ref)
 	require.Equal(t, map[string]Property{"name": {Type: "string"}}, parser.doc.Components.Schemas["StructForAlias"].Properties)
 
 	// nested alias
-	p, err = parser.typeToProperty("", "NestedAlias", getFile(t, "tests", "tests/alias_structs.go", ""))
+	p, err = parser.typeToProperty(parser.mustParseType("NestedAlias", getFile(t, "tests", "tests/alias_structs.go", "")))
 	require.Nil(t, err)
 	require.Equal(t, "#/components/schemas/NestedStruct", p.Ref)
+
+	// alias for simple type
+	p, err = parser.typeToProperty(parser.mustParseType("SimpleAlias", getFile(t, "tests", "tests/alias_structs.go", "")))
+	require.Nil(t, err)
+	require.Equal(t, "string", p.Type)
+
+	// alias for nested simple type
+	p, err = parser.typeToProperty(parser.mustParseType("NestedSimpleAlias", getFile(t, "tests", "tests/alias_structs.go", "")))
+	require.Nil(t, err)
+	require.Equal(t, "", p.Ref)
+	require.Equal(t, "string", p.Type)
 }
 
 func TestParseTags(t *testing.T) {
 	tags := parseTags("@openapiTags foo,  bar")
 	require.Equal(t, []string{"foo", "bar"}, tags)
+}
+
+func TestParseType(t *testing.T) {
+	parser := NewParser(&Doc{
+		OpenAPI:    "3.0.0",
+		Paths:      map[string]Path{},
+		Components: Component{map[string]SecurityScheme{}, map[string]*Schema{}}}, newStructsParser())
+
+	_, err := parser.parseType("User", getFile(t, "nested", "tests/nested/nested.go", "github.com/onrik/gaws/tests/nested"))
+	require.NotNil(t, err)
+	require.Equal(t, "type with name 'User' was not found in package 'tests/nested' with import path 'github.com/onrik/gaws/tests/nested'", err.Error())
 }

--- a/structs.go
+++ b/structs.go
@@ -9,12 +9,15 @@ import (
 	"strings"
 )
 
+const systemFieldName = "_"
+
 type StructField struct {
 	Name       string
 	Type       string
 	Tag        string
 	IsExported bool
 	IsPointer  bool
+	IsSystem   bool
 }
 
 type Struct struct {
@@ -94,17 +97,23 @@ func (p *structsParser) inspectFile(importPath string) func(node ast.Node) bool 
 			if len(field.Names) > 0 {
 				f.Name = field.Names[0].Name
 				f.IsExported = field.Names[0].IsExported()
+				f.IsSystem = f.Name == systemFieldName
 			}
+
 			if field.Tag != nil {
 				f.Tag = field.Tag.Value
 			}
-			if !f.IsExported {
-				continue
-			}
-			f.Type = getType(field.Type)
-			f.IsPointer = strings.HasPrefix(f.Type, "*")
-			if f.Type == "" {
-				continue
+
+			if !f.IsSystem {
+				if !f.IsExported {
+					continue
+				}
+
+				f.Type = getType(field.Type)
+				f.IsPointer = strings.HasPrefix(f.Type, "*")
+				if f.Type == "" {
+					continue
+				}
 			}
 
 			fields = append(fields, f)

--- a/structs_test.go
+++ b/structs_test.go
@@ -13,7 +13,7 @@ func TestParseStructs(t *testing.T) {
 	st, err := p.parse(Package{FSPath: "./tests/", ImportPath: ""})
 	require.NoError(t, err)
 	require.Nil(t, err)
-	require.Equal(t, 14, len(st))
+	require.Equal(t, 15, len(st))
 
 	s, ok := st["User"]
 	require.True(t, ok)
@@ -69,4 +69,32 @@ func TestParseStructs(t *testing.T) {
 
 	// parsed package should be cached
 	require.NotNil(t, p.structs["encoding/json"]["RawMessage"])
+
+	// parse struct description
+	f = NewFile(pkgs["tests"].Files["tests/description_structs.go"], "./tests/", "")
+	st, err = p.parse(f.Pkg)
+	require.NoError(t, err)
+	require.Equal(t, Struct{
+		Pkg:    "",
+		Name:   "DescriptionStruct",
+		Origin: "",
+		Fields: []StructField{
+			{
+				Name:       "_",
+				Type:       "",
+				Tag:        "`json:\"-\" openapiDesc:\"Test description\"`",
+				IsExported: false,
+				IsPointer:  false,
+				IsSystem:   true,
+			},
+			{
+				Name:       "ID",
+				Type:       "int",
+				Tag:        "",
+				IsExported: true,
+				IsPointer:  false,
+				IsSystem:   false,
+			},
+		},
+	}, st["DescriptionStruct"])
 }

--- a/structs_test.go
+++ b/structs_test.go
@@ -13,7 +13,7 @@ func TestParseStructs(t *testing.T) {
 	st, err := p.parse(Package{FSPath: "./tests/", ImportPath: ""})
 	require.NoError(t, err)
 	require.Nil(t, err)
-	require.Equal(t, 12, len(st))
+	require.Equal(t, 14, len(st))
 
 	s, ok := st["User"]
 	require.True(t, ok)
@@ -69,26 +69,4 @@ func TestParseStructs(t *testing.T) {
 
 	// parsed package should be cached
 	require.NotNil(t, p.structs["encoding/json"]["RawMessage"])
-
-	//s = structByName(p.structs, "NestedAlias", pkgs["tests"].Files["tests/alias_structs.go"])
-	//require.NotNil(t, s)
-	//require.Equal(t, "", s.Pkg)
-	//require.Equal(t, []StructField(nil), s.Fields)
-	//require.Equal(t, "nested.NestedStruct", s.Origin)
-	//
-	//// nested struct
-	//s = structByName(p.structs, "nested.NestedStruct", pkgs["tests"].Files["tests/structs4.go"])
-	//require.NotNil(t, s)
-	//require.Equal(t, "github.com/onrik/gaws/tests/nested", s.Pkg)
-
-	// TODO: uncomment this test when deep parsing will be enabled
-	// even more nested struct with duplicate module name
-	//pkgs, err = parser.ParseDir(token.NewFileSet(), "./tests/nested", nil, parser.ParseComments)
-	//if err != nil {
-	//	require.Nil(t, err)
-	//}
-	//
-	//s = structByName(p.structs, "nested.NestedStruct", pkgs["nested"].Files["tests/nested/nested.go"])
-	//require.NotNil(t, s)
-	//require.Equal(t, "github.com/onrik/gaws/tests/nested/nested", s.Pkg)
 }

--- a/tests/alias_structs.go
+++ b/tests/alias_structs.go
@@ -11,3 +11,7 @@ type StructForAlias struct {
 type Alias StructForAlias
 
 type NestedAlias nested.NestedStruct
+
+type SimpleAlias string
+
+type NestedSimpleAlias nested.NestedSimpleAlias

--- a/tests/description_structs.go
+++ b/tests/description_structs.go
@@ -1,0 +1,6 @@
+package tests
+
+type DescriptionStruct struct {
+	_  struct{} `json:"-" openapiDesc:"Test description"`
+	ID int
+}

--- a/tests/nested/nested.go
+++ b/tests/nested/nested.go
@@ -6,3 +6,5 @@ type NestedStruct struct {
 	ID     int
 	Nested nested.NestedStruct
 }
+
+type NestedSimpleAlias string

--- a/type.go
+++ b/type.go
@@ -1,0 +1,19 @@
+package main
+
+type ParsedTypeKind int
+
+const (
+	baseType ParsedTypeKind = iota + 1
+	timeType
+	mapType
+	arrayType
+	structType
+)
+
+// ParsedType represents parsed type of value
+type ParsedType struct {
+	Kind   ParsedTypeKind
+	Name   string
+	File   File
+	Nested *ParsedType
+}


### PR DESCRIPTION
 - Alias types now fully resolves to its core type even from another package and multiple aliases chain. 
 - Reworks general type parsing via split type parsing and property / schema generation to different functions.
 - Description definition for structs via embeded unanimous struct tags